### PR TITLE
Replaced EventLoop with EventLoopWindowTarget

### DIFF
--- a/vulkano-win/src/lib.rs
+++ b/vulkano-win/src/lib.rs
@@ -14,7 +14,7 @@ use vulkano::swapchain::Surface;
 use vulkano::swapchain::SurfaceCreationError;
 use winit::window::Window;
 use winit::window::WindowBuilder;
-use winit::event_loop::EventLoop;
+use winit::event_loop::EventLoopWindowTarget;
 use winit::error::OsError as WindowCreationError;
 
 #[cfg(target_os = "macos")]
@@ -61,13 +61,13 @@ where
 
 pub trait VkSurfaceBuild<E> {
     fn build_vk_surface(
-        self, event_loop: &EventLoop<E>, instance: Arc<Instance>,
+        self, event_loop: &EventLoopWindowTarget<E>, instance: Arc<Instance>,
     ) -> Result<Arc<Surface<Window>>, CreationError>;
 }
 
 impl<E> VkSurfaceBuild<E> for WindowBuilder {
     fn build_vk_surface(
-        self, event_loop: &EventLoop<E>, instance: Arc<Instance>,
+        self, event_loop: &EventLoopWindowTarget<E>, instance: Arc<Instance>,
     ) -> Result<Arc<Surface<Window>>, CreationError> {
         let window = self.build(event_loop)?;
         Ok(create_vk_surface(window, instance)?)


### PR DESCRIPTION
This allows for creating new windows in EventLoop::run.

In winit 0.20 the EventLoop struct is consumed when calling run and a reference to EventLoopWindowTarget is given handed back. 
All relevant functions in winit use this struct instead and EventLoop implements Deref<Target=EventLoopWindowTarget> to transparently convert when necessary.
